### PR TITLE
Add OWNERS file for prow integration

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+filters:
+  .*:
+    approvers:
+    - pliurh
+    - zshi-redhat 
+    - fedepaol
+    - schseba
+options: {}


### PR DESCRIPTION
With https://github.com/openshift/release/pull/7153 we enable the Prow integration (for reviews / merge only). 
This requires a OWNERS file to enable the full review / accept workflow.