### PR TITLE
add node selector for the debug pod and increase timeout

### DIFF
--- a/conformance/operator_test.go
+++ b/conformance/operator_test.go
@@ -39,7 +39,7 @@ var _ = Describe("operator", func() {
 			res, err := cluster.SriovStable(operatorNamespace, clients)
 			Expect(err).ToNot(HaveOccurred())
 			return res
-		}, 3*time.Minute, 1*time.Second).Should(Equal(true))
+		}, 10*time.Minute, 1*time.Second).Should(Equal(true))
 	})
 
 	var _ = Describe("Configuration", func() {
@@ -382,9 +382,9 @@ var _ = Describe("operator", func() {
 					res, err := cluster.SriovStable(operatorNamespace, clients)
 					Expect(err).ToNot(HaveOccurred())
 					return res
-				}, 7*time.Minute, 1*time.Second).Should(BeTrue())
+				}, 10*time.Minute, 1*time.Second).Should(BeTrue())
 
-				debugPod = pod.DefineWithHostNetwork()
+				debugPod = pod.DefineWithHostNetwork(node)
 				err = clients.Create(context.Background(), debugPod)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() corev1.PodPhase {
@@ -641,7 +641,7 @@ var _ = Describe("operator", func() {
 					stable, err := cluster.SriovStable(operatorNamespace, clients)
 					Expect(err).ToNot(HaveOccurred())
 					return stable
-				}, 5*time.Minute, 1*time.Second).Should(Equal(true))
+				}, 10*time.Minute, 1*time.Second).Should(Equal(true))
 
 				Eventually(func() int64 {
 					testedNode, err := clients.Nodes().Get(node, metav1.GetOptions{})

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -36,9 +36,12 @@ func DefineWithNetworks(networks []string) *corev1.Pod {
 	return podObject
 }
 
-func DefineWithHostNetwork() *corev1.Pod {
+func DefineWithHostNetwork(nodeName string) *corev1.Pod {
 	podObject := getDefinition()
 	podObject.Spec.HostNetwork = true
+	podObject.Spec.NodeSelector = map[string]string{
+		"kubernetes.io/hostname": nodeName,
+	}
 
 	return podObject
 }


### PR DESCRIPTION
This commit also increase the timeout on the SriovStable eventually.

We need this change because on mellanox if we change the number of VFs to a larger number the sriov config daemon will need to reboot the node.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>