### PR TITLE
Check for a mellanox card

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -64,6 +64,21 @@ func (n *EnabledNodes) FindOneSriovDevice(node string) (*sriovv1.InterfaceExt, e
 	return nil, fmt.Errorf("Unable to find sriov devices in node %s", node)
 }
 
+// FindOneMellanoxSriovDevice retrieves a valid sriov device for the given node.
+func (n *EnabledNodes) FindOneMellanoxSriovDevice(node string) (*sriovv1.InterfaceExt, error) {
+	s, ok := n.States[node]
+	if !ok {
+		return nil, fmt.Errorf("Node %s not found", node)
+	}
+	for _, itf := range s.Status.Interfaces {
+		if itf.Driver == "mlx5_core" {
+			return &itf, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Unable to find a mellanox sriov devices in node %s", node)
+}
+
 // SriovStable tells if all the node states are in sync (and the cluster is ready for another round of tests)
 func SriovStable(operatorNamespace string, clients *testclient.ClientSet) (bool, error) {
 	nodeStates, err := clients.SriovNetworkNodeStates(operatorNamespace).List(metav1.ListOptions{})


### PR DESCRIPTION
This commit checks if there is a mellanox card for the flags valitation test.

If we find the mellanox card we use it of not we fall back to any supported sriov card and skip the rate limit test

Signed-off-by: Sebastian Sch <sebassch@gmail.com>