### PR TITLE
Change the logic to find the pod's vf index.

### DIFF
--- a/conformance/vfs_assignement_test.go
+++ b/conformance/vfs_assignement_test.go
@@ -63,7 +63,7 @@ var _ = Describe("pod", func() {
 					"VfGroups": ContainElement(sriovv1.VfGroup{ResourceName: resourceName, DeviceType: "netdevice", VfRange: "0-4"}),
 				})), "Error SriovNetworkNodeState doesn't contain required elements")
 
-			waitForSriovToStable()
+			waitForSRIOVStable()
 
 			Eventually(func() int64 {
 				testedNode, err := clients.Nodes().Get(testNode, metav1.GetOptions{})


### PR DESCRIPTION
Instead of doing deltas in the host's namespace to understand what interface was moved to the pod, we relate them via sysfs. This should ensure a more reliable mechanism and less flakiness.

