### PR TITLE
Add a check cluster function

### DIFF
--- a/conformance/vfs_assignement_test.go
+++ b/conformance/vfs_assignement_test.go
@@ -31,10 +31,17 @@ var _ = Describe("pod", func() {
 		err = namespaces.Clean(operatorNamespace, namespaces.Test, clients)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(func() bool {
+			isClusterReady, err := cluster.IsClusterStable(clients)
+			Expect(err).ToNot(HaveOccurred())
+			if !isClusterReady {
+				return isClusterReady
+			}
+
 			res, err := cluster.SriovStable(operatorNamespace, clients)
 			Expect(err).ToNot(HaveOccurred())
+
 			return res
-		}, 10*time.Minute, 1*time.Second).Should(BeTrue())
+		}, 10*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 
 	var _ = Describe("Configuration", func() {


### PR DESCRIPTION
This change add a check cluster status function in the BeforeEach.

I also include a change on the stable sriov function if there is no status I mark the cluster as not ready yet.

This change is because when a node came up after a reboot the config daemon mark remove the status field but it doesn't mean the policy is in synced status.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>